### PR TITLE
add validation error instead of raising error when duplicate key

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -123,7 +123,6 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
   end
 
   define_method CREATE_METHOD_NAME do
-    count = 0
     begin
       self.unique_key = unique_key.blank? ? generate_unique_key : unique_key
       super()

--- a/lib/shortener/version.rb
+++ b/lib/shortener/version.rb
@@ -1,3 +1,3 @@
 module Shortener
-  VERSION = '0.5.10'
+  VERSION = '0.5.11'
 end


### PR DESCRIPTION
Before, when trying to create a new url with a unique_key that already existed (e.g. "foo"), the validation would only take effect, when upper and lower case were the same. If case was different (e.g. "Foo"), it would generate a random unique_key. When the user now wanted to change the random unique_key back to the initially intended key ("Foo"), it would raise an exception, resulting in an error page for the user.

This is confusing for the user.

Now, it will right away on save tell the user, that the key is already existing.
